### PR TITLE
fix(config.rs): updated if/else in config init to write if the config…

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -115,6 +115,8 @@ run_hidden = true
         } else {
             println!("Closing without generating config!");
         }
+    } else {
+        fs::write(path_clone, DEFAULT_CONFIG).expect("Unable to write file");
     }
 }
 


### PR DESCRIPTION
… file doesn't exist

The if check that was looking for the config file didn't write the default config if the file wasn't found. Corrected with this patch

Resolves issue #3